### PR TITLE
add (3,2)-QRAC Hamiltonian

### DIFF
--- a/jijtranspiler_qiskit/qrao/__init__.py
+++ b/jijtranspiler_qiskit/qrao/__init__.py
@@ -1,11 +1,21 @@
 from .graph_coloring import greedy_graph_coloring
 from .qrao31 import color_group_to_qrac_encode, qrac31_encode_ising
-from .to_qrac import transpile_to_qrac31_hamiltonian, transpile_to_qrac21_hamiltonian
+from .qrao21 import qrac21_encode_ising
+from .qrao32 import qrac32_encode_ising
+
+from .to_qrac import (
+    transpile_to_qrac31_hamiltonian,
+    transpile_to_qrac21_hamiltonian,
+    transpile_to_qrac32_hamiltonian,
+)
 
 __all__ = [
     "greedy_graph_coloring",
     "color_group_to_qrac_encode",
     "qrac31_encode_ising",
+    "qrac21_encode_ising",
+    "qrac32_encode_ising",
     "transpile_to_qrac31_hamiltonian",
+    "transpile_to_qrac21_hamiltonian",
     "transpile_to_qrac21_hamiltonian",
 ]

--- a/jijtranspiler_qiskit/qrao/qrao32.py
+++ b/jijtranspiler_qiskit/qrao/qrao32.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+import numpy as np
+import qiskit.quantum_info as qk_ope
+from jijtranspiler_qiskit.ising_qubo import IsingModel
+from .qrao31 import Pauli, color_group_to_qrac_encode
+
+
+def create_pauli_x_prime_term(
+    xps: list[np.ndarray], zps: list[np.ndarray], coeffs: list[float], idx: int
+):
+    xps[0][idx] = True
+    xps[0][idx + 1] = True
+    coeffs[0] *= 1 / 2
+
+    xps[1][idx] = True
+    zps[1][idx + 1] = True
+    coeffs[1] *= 1 / 2
+
+    zps[2][idx] = True
+
+
+def create_pauli_y_prime_term(
+    xps: list[np.ndarray], zps: list[np.ndarray], coeffs: list[float], idx: int
+):
+    xps[0][idx + 1] = True
+    coeffs[0] *= 1 / 2
+
+    zps[1][idx + 1] = True
+
+    xps[2][idx] = True
+    zps[2][idx] = True
+    xps[2][idx + 1] = True
+    zps[2][idx + 1] = True
+    coeffs[2] *= 1 / 2
+
+
+def create_pauli_z_prime_term(
+    xps: list[np.ndarray], zps: list[np.ndarray], coeffs: list[float], idx: int
+):
+    zps[0][idx] = True
+    zps[0][idx + 1] = True
+
+    xps[1][idx] = True
+    coeffs[1] *= -1 / 2
+
+    zps[2][idx] = True
+    xps[2][idx + 1] = True
+    coeffs[2] *= -1 / 2
+
+
+def create_pauli_prime_terms(operator: Pauli, index: int, n_qubit: int):
+    coeffs = [1.0, 1.0, 1.0]
+    zps = [
+        np.zeros(n_qubit, dtype=bool),
+        np.zeros(n_qubit, dtype=bool),
+        np.zeros(n_qubit, dtype=bool),
+    ]
+    xps = [
+        np.zeros(n_qubit, dtype=bool),
+        np.zeros(n_qubit, dtype=bool),
+        np.zeros(n_qubit, dtype=bool),
+    ]
+    if operator == Pauli.X:
+        create_pauli_x_prime_term(xps, zps, coeffs, 2 * index)
+    elif operator == Pauli.Y:
+        create_pauli_y_prime_term(xps, zps, coeffs, 2 * index)
+    elif operator == Pauli.Z:
+        create_pauli_z_prime_term(xps, zps, coeffs, 2 * index)
+
+    return xps, zps, coeffs
+
+
+def create_pauli_linear_term(operator: Pauli, index: int, n_qubit: int):
+    xps, zps, coeffs = create_pauli_prime_terms(operator, index, n_qubit)
+
+    _pauli_terms: list[qk_ope.SparsePauliOp] = []
+    for z_p, x_p, coeff in zip(zps, xps, coeffs):
+        _pauli_terms.append(qk_ope.SparsePauliOp(qk_ope.Pauli((z_p, x_p)), coeff))
+
+    return _pauli_terms
+
+
+def create_pauli_quad_term(operators: list[Pauli], indices: list[int], n_qubit: int):
+    xps_i, zps_i, coeffs_i = create_pauli_prime_terms(operators[0], indices[0], n_qubit)
+    xps_j, zps_j, coeffs_j = create_pauli_prime_terms(operators[1], indices[1], n_qubit)
+
+    _pauli_terms: list[qk_ope.SparsePauliOp] = []
+    for x_p_i, z_p_i, coeff_i in zip(xps_i, zps_i, coeffs_i):
+        for x_p_j, z_p_j, coeff_j in zip(xps_j, zps_j, coeffs_j):
+            _pauli_terms.append(
+                qk_ope.SparsePauliOp(
+                    qk_ope.Pauli((z_p_i | z_p_j, x_p_i | x_p_j)), coeff_i * coeff_j
+                )
+            )
+
+    return _pauli_terms
+
+
+def qrac32_encode_ising(
+    ising: IsingModel, color_group: dict[int, list[int]]
+) -> tuple[qk_ope.SparsePauliOp, float, dict[int, tuple[int, Pauli]]]:
+    encoded_ope = color_group_to_qrac_encode(color_group)
+
+    pauli_terms: list[qk_ope.SparsePauliOp] = []
+
+    offset = ising.constant
+    n_qubit = 2 * len(color_group)
+
+    # convert linear parts of the objective function into Hamiltonian.
+    for idx, coeff in ising.linear.items():
+        if coeff == 0.0:
+            continue
+
+        color, pauli_kind = encoded_ope[idx]
+        pauli_operator_terms = create_pauli_linear_term(pauli_kind, color, n_qubit)
+
+        pauli_terms.extend(pauli_operator_terms)
+
+    # create Pauli terms
+    for (i, j), coeff in ising.quad.items():
+        if coeff == 0.0:
+            continue
+
+        if i == j:
+            offset += coeff
+            continue
+
+        color_i, pauli_kind_i = encoded_ope[i]
+
+        color_j, pauli_kind_j = encoded_ope[j]
+
+        pauli_operator_terms = create_pauli_quad_term(
+            [pauli_kind_i, pauli_kind_j], [color_i, color_j], n_qubit
+        )
+
+        pauli_terms.extend(pauli_operator_terms)
+
+    if pauli_terms:
+        # Remove paulis whose coefficients are zeros.
+
+        qubit_op = sum(pauli_terms).simplify(atol=0)
+    else:
+        # If there is no variable, we set num_nodes=1 so that qubit_op should be an operator.
+        # If num_nodes=0, I^0 = 1 (int).
+        n_qubit = max(1, n_qubit)
+        qubit_op = qk_ope.SparsePauliOp("I" * n_qubit, 0)
+
+    return qubit_op, offset, encoded_ope

--- a/jijtranspiler_qiskit/qrao/to_qrac.py
+++ b/jijtranspiler_qiskit/qrao/to_qrac.py
@@ -11,6 +11,7 @@ from jijtranspiler_qiskit.ising_qubo import qubo_to_ising
 from .graph_coloring import greedy_graph_coloring
 from .qrao31 import qrac31_encode_ising, Pauli
 from .qrao21 import qrac21_encode_ising
+from .qrao32 import qrac32_encode_ising
 
 
 class QRACBuilder(ABC):
@@ -96,3 +97,29 @@ def transpile_to_qrac21_hamiltonian(compiled_instance, normalize=True) -> QRAC21
         compiled_instance, normalize=normalize
     )
     return QRAC21Builder(pubo_builder, compiled_instance)
+
+
+class QRAC32Builder(QRACBuilder):
+    def get_hamiltonian(
+        self, multipliers=None, detail_parameter=None
+    ) -> tuple[qk_info.SparsePauliOp, float, QRACEncodingCache]:
+        qubo, constant = self.pubo_builder.get_qubo_dict(
+            multipliers=multipliers, detail_parameters=detail_parameter
+        )
+        ising = qubo_to_ising(qubo)
+        _, color_group = greedy_graph_coloring(
+            ising.quad.keys(), max_color_group_size=3
+        )
+        qrac_hamiltonian, offset, encoding = qrac32_encode_ising(ising, color_group)
+        return (
+            qrac_hamiltonian,
+            offset + constant,
+            QRACEncodingCache(color_group, encoding),
+        )
+
+
+def transpile_to_qrac32_hamiltonian(compiled_instance, normalize=True) -> QRAC32Builder:
+    pubo_builder = jmt.core.pubo.transpile_to_pubo(
+        compiled_instance, normalize=normalize
+    )
+    return QRAC32Builder(pubo_builder, compiled_instance)

--- a/tests/test_qrao32.py
+++ b/tests/test_qrao32.py
@@ -1,0 +1,104 @@
+import qiskit as qk
+import qiskit.quantum_info as qk_ope
+import numpy as np
+from jijtranspiler_qiskit.qrao.qrao32 import (
+    create_pauli_x_prime_term,
+    create_pauli_y_prime_term,
+    create_pauli_z_prime_term,
+)
+
+
+def test_create_pauli_x_prime_term():
+    # The numbering of qubit is different between Qiskit and the paper
+    # The operator X' is defined as follows (in qiskit notation):
+    # X' = 1/2XX + 1/2ZX + IZ
+    xps = [
+        np.zeros(2, dtype=bool),
+        np.zeros(2, dtype=bool),
+        np.zeros(2, dtype=bool),
+    ]
+    zps = [
+        np.zeros(2, dtype=bool),
+        np.zeros(2, dtype=bool),
+        np.zeros(2, dtype=bool),
+    ]
+    coeffs = [1.0, 1.0, 1.0]
+    idx = 0
+
+    create_pauli_x_prime_term(xps, zps, coeffs, idx)
+
+    _pauli_terms: list[qk_ope.SparsePauliOp] = []
+    for z_p, x_p, coeff in zip(zps, xps, coeffs):
+        _pauli_terms.append(qk_ope.SparsePauliOp(qk_ope.Pauli((z_p, x_p)), coeff))
+
+    answer = [
+        qk_ope.SparsePauliOp(qk_ope.Pauli("XX"), 1 / 2),
+        qk_ope.SparsePauliOp(qk_ope.Pauli("ZX"), 1 / 2),
+        qk_ope.SparsePauliOp(qk_ope.Pauli("IZ"), 1.0),
+    ]
+
+    assert _pauli_terms == answer
+
+
+def test_create_pauli_y_prime_term():
+    # The numbering of qubit is different between Qiskit and the paper
+    # The operator Y' is defined as follows (in qiskit notation):
+    # Y' = 1/2XI + ZI + 1/2YY
+    xps = [
+        np.zeros(2, dtype=bool),
+        np.zeros(2, dtype=bool),
+        np.zeros(2, dtype=bool),
+    ]
+    zps = [
+        np.zeros(2, dtype=bool),
+        np.zeros(2, dtype=bool),
+        np.zeros(2, dtype=bool),
+    ]
+    coeffs = [1.0, 1.0, 1.0]
+    idx = 0
+
+    create_pauli_y_prime_term(xps, zps, coeffs, idx)
+
+    _pauli_terms: list[qk_ope.SparsePauliOp] = []
+    for z_p, x_p, coeff in zip(zps, xps, coeffs):
+        _pauli_terms.append(qk_ope.SparsePauliOp(qk_ope.Pauli((z_p, x_p)), coeff))
+
+    answer = [
+        qk_ope.SparsePauliOp(qk_ope.Pauli("XI"), 1 / 2),
+        qk_ope.SparsePauliOp(qk_ope.Pauli("ZI"), 1.0),
+        qk_ope.SparsePauliOp(qk_ope.Pauli("YY"), 1 / 2),
+    ]
+
+    assert _pauli_terms == answer
+
+
+def test_create_pauli_z_prime_term():
+    # The numbering of qubit is different between Qiskit and the paper
+    # The operator Z' is defined as follows (in qiskit notation):
+    # Z' = ZZ - 1/2IX - 1/2XZ
+    xps = [
+        np.zeros(2, dtype=bool),
+        np.zeros(2, dtype=bool),
+        np.zeros(2, dtype=bool),
+    ]
+    zps = [
+        np.zeros(2, dtype=bool),
+        np.zeros(2, dtype=bool),
+        np.zeros(2, dtype=bool),
+    ]
+    coeffs = [1.0, 1.0, 1.0]
+    idx = 0
+
+    create_pauli_z_prime_term(xps, zps, coeffs, idx)
+
+    _pauli_terms: list[qk_ope.SparsePauliOp] = []
+    for z_p, x_p, coeff in zip(zps, xps, coeffs):
+        _pauli_terms.append(qk_ope.SparsePauliOp(qk_ope.Pauli((z_p, x_p)), coeff))
+
+    answer = [
+        qk_ope.SparsePauliOp(qk_ope.Pauli("ZZ"), 1.0),
+        qk_ope.SparsePauliOp(qk_ope.Pauli("IX"), -1 / 2),
+        qk_ope.SparsePauliOp(qk_ope.Pauli("XZ"), -1 / 2),
+    ]
+
+    assert _pauli_terms == answer


### PR DESCRIPTION
# 実装したこと
(3,2)-QRAC Hamiltonianを生成する機能を追加しました。

$X'$などが2qubit演算子の和の3項で構成されていることもあり、(イジングにおいて)線形項の場合と２次項の場合を(3,1)-QRACのように共通の関数で行うことが難しかったので、線形項と２次項を別の関数で扱うようにしています。

各$X'$のような2Qubit演算子に関しては、テストしているのですが、最後の生成される演算子はテストできていないです。

# 確認したいこと
1. $X'$が3項あるので、その表現のために `list[np.ndarray]`にしていますが、シンプルに2次元のnumpy配列の方がいいですか？記述はnumpyの方がシンプルになるのですが、要素アクセスがnumpyよりlistの方が速いかなと思って、現在は`list[np.ndarray]`を選択しています。
2. $X'Z'$のような積を作成するときの記述方法。こちらは、特に確認したいことで、3項かける3項で合計9項が出てくるのですが、現在はこれを単純にそれぞれの演算子に対してループを回すことで、各項を作成しています。こちらの作成のやり方で効率的なやり方はありますか?
3. $X'Z'$のような積を作成するときに各演算子の名前づけで、$i,j$をつけて区別していますが、一般的にどういう名前づけをするのが適切ですか？