### PR TITLE
Hotfix/qrao linear case

### DIFF
--- a/jijmodeling_transpiler_quantum/core/qrac/__init__.py
+++ b/jijmodeling_transpiler_quantum/core/qrac/__init__.py
@@ -3,6 +3,6 @@ This module provides utilities for the Quantum Random Access Coding (QRAC).
 Ex: QRAC utilizes are used Quantum Random Access Optimization (QRAO).
 """
 
-from .graph_coloring import greedy_graph_coloring
+from .graph_coloring import greedy_graph_coloring, check_linear_term
 
-__all__ = ["greedy_graph_coloring"]
+__all__ = ["greedy_graph_coloring", "check_linear_term"]

--- a/jijmodeling_transpiler_quantum/core/qrac/graph_coloring.py
+++ b/jijmodeling_transpiler_quantum/core/qrac/graph_coloring.py
@@ -71,3 +71,39 @@ def greedy_graph_coloring(
             max_color += 1
 
     return coloring, color_group
+
+
+def check_linear_term(
+    color_group: dict[int, list[int]],
+    linear_term_index: list[int],
+    max_color_group_size: int,
+) -> dict[int, list[int]]:
+    """Search for items within the index of linear term that have not been assigned to the color_group, and add them.
+
+    Args:
+        color_group (dict[int, list[int]]): color_group
+        linear_term_index (list[int]): list of index of linear term
+        max_color_group_size (int): the maximum number of encoding qubits. if you want to use for the qrac31, set 3.
+
+    Returns:
+        dict[int, list[int]]: color_group which added items within the index of linear term that have not been assigned to the color_group.
+    """
+    idx_in_color_group = []
+    for v in color_group.values():
+        idx_in_color_group.extend(v)
+
+    max_idx = max(color_group.keys())
+    value_counter = 1
+    for idx in linear_term_index:
+        if idx not in idx_in_color_group:
+            if value_counter == 1:
+                color_group[max_idx + 1] = []
+
+            color_group[max_idx + 1].append(idx)
+            value_counter += 1
+
+            if value_counter > max_color_group_size:
+                max_idx += 1
+                value_counter = 1
+
+    return color_group

--- a/jijmodeling_transpiler_quantum/qiskit/qrao/__init__.py
+++ b/jijmodeling_transpiler_quantum/qiskit/qrao/__init__.py
@@ -1,4 +1,5 @@
 from .qrao31 import color_group_to_qrac_encode, qrac31_encode_ising
+from .qrao21 import qrac21_encode_ising
 from .to_qrac import (
     transpile_to_qrac31_hamiltonian,
     transpile_to_qrac21_hamiltonian,
@@ -9,6 +10,7 @@ from .to_qrac import (
 __all__ = [
     "color_group_to_qrac_encode",
     "qrac31_encode_ising",
+    "qrac21_encode_ising",
     "transpile_to_qrac31_hamiltonian",
     "transpile_to_qrac21_hamiltonian",
     "transpile_to_qrac32_hamiltonian",

--- a/jijmodeling_transpiler_quantum/qiskit/qrao/to_qrac.py
+++ b/jijmodeling_transpiler_quantum/qiskit/qrao/to_qrac.py
@@ -42,7 +42,8 @@ class QRACBuilder(ABC):
         self, binary_list: typ.Iterable[list[int]]
     ) -> jm.SampleSet:
         binary_results = [
-            {i: value for i, value in enumerate(binary)} for binary in binary_list
+            {i: value for i, value in enumerate(binary)}
+            for binary in binary_list
         ]
         binary_encoder = self.pubo_builder.binary_encoder
         decoded: jm.SampleSet = (
@@ -81,10 +82,16 @@ class QRAC31Builder(QRACBuilder):
             multipliers=multipliers, detail_parameters=detail_parameters
         )
         ising = jmt_qc.qubo_to_ising(qubo)
+        max_color_group_size = 3
         _, color_group = jmt_qc.greedy_graph_coloring(
-            ising.quad.keys(), max_color_group_size=3
+            ising.quad.keys(), max_color_group_size=max_color_group_size
         )
-        qrac_hamiltonian, offset, encoding = qrac31_encode_ising(ising, color_group)
+        color_group = jmt_qc.qrac.check_linear_term(
+            color_group, ising.linear.keys(), max_color_group_size
+        )
+        qrac_hamiltonian, offset, encoding = qrac31_encode_ising(
+            ising, color_group
+        )
         return (
             qrac_hamiltonian,
             offset + constant,
@@ -133,10 +140,17 @@ class QRAC21Builder(QRACBuilder):
             multipliers=multipliers, detail_parameters=detail_parameters
         )
         ising = jmt_qc.qubo_to_ising(qubo)
+        max_color_group_size = 2
+
         _, color_group = jmt_qc.greedy_graph_coloring(
-            ising.quad.keys(), max_color_group_size=2
+            ising.quad.keys(), max_color_group_size=max_color_group_size
         )
-        qrac_hamiltonian, offset, encoding = qrac21_encode_ising(ising, color_group)
+        color_group = jmt_qc.qrac.check_linear_term(
+            color_group, ising.linear.keys(), max_color_group_size
+        )
+        qrac_hamiltonian, offset, encoding = qrac21_encode_ising(
+            ising, color_group
+        )
         return (
             qrac_hamiltonian,
             offset + constant,
@@ -185,10 +199,16 @@ class QRAC32Builder(QRACBuilder):
             multipliers=multipliers, detail_parameters=detail_parameters
         )
         ising = jmt_qc.qubo_to_ising(qubo)
+        max_color_group_size = 3
         _, color_group = jmt_qc.greedy_graph_coloring(
-            ising.quad.keys(), max_color_group_size=3
+            ising.quad.keys(), max_color_group_size=max_color_group_size
         )
-        qrac_hamiltonian, offset, encoding = qrac32_encode_ising(ising, color_group)
+        color_group = jmt_qc.qrac.check_linear_term(
+            color_group, ising.linear.keys(), max_color_group_size
+        )
+        qrac_hamiltonian, offset, encoding = qrac32_encode_ising(
+            ising, color_group
+        )
         return (
             qrac_hamiltonian,
             offset + constant,
@@ -237,7 +257,9 @@ class QRACSpaceEfficientBuilder(QRACBuilder):
             multipliers=multipliers, detail_parameters=detail_parameters
         )
         ising = jmt_qc.qubo_to_ising(qubo)
-        qrac_hamiltonian, offset, encoding = qrac_space_efficient_encode_ising(ising)
+        qrac_hamiltonian, offset, encoding = qrac_space_efficient_encode_ising(
+            ising
+        )
         return (
             qrac_hamiltonian,
             offset + constant,

--- a/tests/test_qrac.py
+++ b/tests/test_qrac.py
@@ -1,0 +1,14 @@
+from jijmodeling_transpiler_quantum.core.ising_qubo import IsingModel
+from jijmodeling_transpiler_quantum.core.qrac import greedy_graph_coloring
+from jijmodeling_transpiler_quantum.qiskit.qrao import qrac31_encode_ising
+
+
+# TODO:test name
+def test_greedy():
+    ising = IsingModel({(0, 1): 2.0}, {2: 5.0}, 6.0)
+    _, color_group = greedy_graph_coloring(
+        ising.quad.keys(), max_color_group_size=3
+    )
+    qrac_hamiltonian, offset, encoding = qrac31_encode_ising(
+        ising, color_group
+    )

--- a/tests/test_qrac.py
+++ b/tests/test_qrac.py
@@ -1,9 +1,13 @@
+import jijmodeling_transpiler_quantum.qiskit as jtq
 from jijmodeling_transpiler_quantum.core.ising_qubo import IsingModel
 from jijmodeling_transpiler_quantum.core.qrac import (
     greedy_graph_coloring,
     check_linear_term,
 )
-from jijmodeling_transpiler_quantum.qiskit.qrao import qrac31_encode_ising
+from jijmodeling_transpiler_quantum.qiskit.qrao import (
+    qrac31_encode_ising,
+    qrac21_encode_ising,
+)
 
 
 # TODO:test name
@@ -35,5 +39,22 @@ def test_greedy():
     )
 
     qrac_hamiltonian, offset, encoding = qrac31_encode_ising(
+        ising, color_group
+    )
+
+    ising = IsingModel(
+        {(0, 1): 2.0, (0, 2): 1.0},
+        {2: 5.0, 3: 2.0, 4: 1.0, 5: 1.0, 6: 1.0},
+        6.0,
+    )
+    max_color_group_size = 2
+    _, color_group = greedy_graph_coloring(
+        ising.quad.keys(), max_color_group_size=max_color_group_size
+    )
+    color_group = check_linear_term(
+        color_group, ising.linear.keys(), max_color_group_size
+    )
+
+    qrac_hamiltonian, offset, encoding = qrac21_encode_ising(
         ising, color_group
     )

--- a/tests/test_qrac.py
+++ b/tests/test_qrac.py
@@ -10,8 +10,7 @@ from jijmodeling_transpiler_quantum.qiskit.qrao import (
 )
 
 
-# TODO:test name
-def test_greedy():
+def test_check_linear_term():
     ising = IsingModel({(0, 1): 2.0, (0, 2): 1.0}, {2: 5.0, 3: 2.0}, 6.0)
     max_color_group_size = 3
     _, color_group = greedy_graph_coloring(

--- a/tests/test_qrac.py
+++ b/tests/test_qrac.py
@@ -1,14 +1,39 @@
 from jijmodeling_transpiler_quantum.core.ising_qubo import IsingModel
-from jijmodeling_transpiler_quantum.core.qrac import greedy_graph_coloring
+from jijmodeling_transpiler_quantum.core.qrac import (
+    greedy_graph_coloring,
+    check_linear_term,
+)
 from jijmodeling_transpiler_quantum.qiskit.qrao import qrac31_encode_ising
 
 
 # TODO:test name
 def test_greedy():
-    ising = IsingModel({(0, 1): 2.0}, {2: 5.0}, 6.0)
+    ising = IsingModel({(0, 1): 2.0, (0, 2): 1.0}, {2: 5.0, 3: 2.0}, 6.0)
+    max_color_group_size = 3
     _, color_group = greedy_graph_coloring(
-        ising.quad.keys(), max_color_group_size=3
+        ising.quad.keys(), max_color_group_size=max_color_group_size
     )
+    color_group = check_linear_term(
+        color_group, ising.linear.keys(), max_color_group_size
+    )
+
+    qrac_hamiltonian, offset, encoding = qrac31_encode_ising(
+        ising, color_group
+    )
+
+    ising = IsingModel(
+        {(0, 1): 2.0, (0, 2): 1.0},
+        {2: 5.0, 3: 2.0, 4: 1.0, 5: 1.0, 6: 1.0},
+        6.0,
+    )
+    max_color_group_size = 3
+    _, color_group = greedy_graph_coloring(
+        ising.quad.keys(), max_color_group_size=max_color_group_size
+    )
+    color_group = check_linear_term(
+        color_group, ising.linear.keys(), max_color_group_size
+    )
+
     qrac_hamiltonian, offset, encoding = qrac31_encode_ising(
         ising, color_group
     )


### PR DESCRIPTION
# Change
- #24 
の解決のために、相互作用項を見て作成されたcolor_groupの中のインデックスについて、線形項に含まれるインデックスで漏れがないかを調べ、漏れがあった場合、別のcolor_groupに追加するという`check_linear_term`関数を追加しました。
線形項に関しては、可換性の問題が起きないので、encodeする最大数に従って、詰めてcolor_groupに入れていっています。

最終的に、線形項の情報も追加したcolor_groupをencode Hamiltonianを作成するという形にしています。