### PR TITLE
fix the issues #35

### DIFF
--- a/jijmodeling_transpiler_quantum/core/qrac/graph_coloring.py
+++ b/jijmodeling_transpiler_quantum/core/qrac/graph_coloring.py
@@ -92,7 +92,7 @@ def check_linear_term(
     for v in color_group.values():
         idx_in_color_group.extend(v)
 
-    max_idx = max(color_group.keys())
+    max_idx = max(color_group.keys()) if color_group else -1
     value_counter = 1
     for idx in linear_term_index:
         if idx not in idx_in_color_group:

--- a/jijmodeling_transpiler_quantum/core/qrac/graph_coloring.py
+++ b/jijmodeling_transpiler_quantum/core/qrac/graph_coloring.py
@@ -92,18 +92,20 @@ def check_linear_term(
     for v in color_group.values():
         idx_in_color_group.extend(v)
 
-    max_idx = max(color_group.keys()) if color_group else -1
-    value_counter = 1
+    # We're adding a bit to the next index of the 'quad' qubit, affecting only the linear term. 
+    # If the Ising Hamiltonian has only linear terms, making 'quad' empty and causing a 'max' error, we return index 0 to avoid this.
+    qubit_index_for_linear = max(color_group.keys()) + 1 if color_group else 0
+    bits_in_qubits_counter = 1
     for idx in linear_term_index:
         if idx not in idx_in_color_group:
-            if value_counter == 1:
-                color_group[max_idx + 1] = []
+            if bits_in_qubits_counter == 1:
+                color_group[qubit_index_for_linear] = []
 
-            color_group[max_idx + 1].append(idx)
-            value_counter += 1
+            color_group[qubit_index_for_linear].append(idx)
+            bits_in_qubits_counter += 1
 
-            if value_counter > max_color_group_size:
-                max_idx += 1
-                value_counter = 1
+            if bits_in_qubits_counter > max_color_group_size:
+                qubit_index_for_linear += 1
+                bits_in_qubits_counter = 1
 
     return color_group

--- a/tests/test_qrac.py
+++ b/tests/test_qrac.py
@@ -105,3 +105,49 @@ def test_check_linear_term_quri():
     qrac_hamiltonian, offset, encoding = jtqp.qrao.qrac21_encode_ising(
         ising, color_group
     )
+
+
+def test_check_no_quad_term_quri():
+    ising = IsingModel({}, {0:1.0,1:1.0,2: 5.0, 3: 2.0}, 6.0)
+    max_color_group_size = 3
+    _, color_group = greedy_graph_coloring(
+        ising.quad.keys(), max_color_group_size=max_color_group_size
+    )
+    color_group = check_linear_term(
+        color_group, ising.linear.keys(), max_color_group_size
+    )
+
+    qrac_hamiltonian, offset, encoding = jtqp.qrao.qrac31_encode_ising(
+        ising, color_group
+    )
+
+    ising = IsingModel({}, {2: 5.0, 3: 2.0}, 6.0)
+    max_color_group_size = 3
+    _, color_group = greedy_graph_coloring(
+        ising.quad.keys(), max_color_group_size=max_color_group_size
+    )
+    color_group = check_linear_term(
+        color_group, ising.linear.keys(), max_color_group_size
+    )
+
+    qrac_hamiltonian, offset, encoding = jtqp.qrao.qrac31_encode_ising(
+        ising, color_group
+    )
+
+    ising = IsingModel(
+        {},
+        {2: 5.0, 3: 2.0, 4: 1.0, 5: 1.0, 6: 1.0},
+        6.0,
+    )
+    max_color_group_size = 2
+    _, color_group = greedy_graph_coloring(
+        ising.quad.keys(), max_color_group_size=max_color_group_size
+    )
+    color_group = check_linear_term(
+        color_group, ising.linear.keys(), max_color_group_size
+    )
+
+    qrac_hamiltonian, offset, encoding = jtqp.qrao.qrac21_encode_ising(
+        ising, color_group
+    )
+    


### PR DESCRIPTION
# Change
The problem is caused by try to know the current max index of the quad term like the below code
```python
max_idx = max(color_group.keys()) 
```

This causes error when the `color_group` is empty, so I change this as below
```python
max_idx = max(color_group.keys()) if color_group else -1
```
When the dictionary is empty, -1 is returned. This is because we would like to start the linear term from the max index of the quad term, so the initial linear index should be 0, so I set the return value as -1.